### PR TITLE
test: fix and improve html tests

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,5 @@
+bandit; python_version <= "3.8"
+bandit==1.8.3; python_version > "3.8"
 black==24.10.0; python_version > "3.8"
 black; python_version <= "3.8"
 isort; python_version < "3.8"
@@ -7,22 +9,20 @@ pre-commit==4.1.0; python_version > "3.8"
 codespell==v2.4.1
 flake8; python_version < "3.8"
 flake8==7.1.2; python_version >= "3.8"
-bandit; python_version <= "3.8"
-bandit==1.8.3; python_version > "3.8"
 gitlint==v0.19.1
 interrogate
+jsonschema
 mypy==v1.15.0
+playwright
 pytest>=7.2.0
-pytest-xdist
-pytest-cov
 pytest-asyncio
+pytest-cov
 pytest-mock
 pytest-playwright
-playwright
+pytest-xdist
 types-beautifulsoup4
 types-jsonschema
 types-PyYAML
 types-requests
 types-setuptools
 types-toml
-build

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,6 +2,7 @@ bandit; python_version <= "3.8"
 bandit==1.8.3; python_version > "3.8"
 black==24.10.0; python_version > "3.8"
 black; python_version <= "3.8"
+build
 isort; python_version < "3.8"
 isort==6.0.1; python_version >= "3.8"
 pre-commit; python_version <= "3.8"

--- a/doc/how_to_guides/use_intermediate_reports.md
+++ b/doc/how_to_guides/use_intermediate_reports.md
@@ -62,8 +62,10 @@ The "remarks" section allows 6 values:
 2. Unexplored
 3. Confirmed
 4. Mitigated
-5. False Positive
-6. Not Affected
+5. FalsePositive
+6. NotAffected
+
+(Note the lack of spaces)
 
 More details such as how a CVE was mitigated or why it can be ignored can be
 added into the "comments" section.  Other fields such as severity and score can

--- a/test/pages/html_report.py
+++ b/test/pages/html_report.py
@@ -3,8 +3,6 @@
 
 import logging
 import os
-
-# from os import unlink
 from pathlib import Path
 from tempfile import NamedTemporaryFile
 
@@ -16,32 +14,44 @@ from cve_bin_tool.util import CVEData, ProductInfo
 
 
 class HTMLReport:
-    def __init__(self, page: Page, all_cve_data: dict[ProductInfo, CVEData]):
+    def __init__(
+        self,
+        page: Page,
+        all_cve_data: dict[ProductInfo, CVEData],
+        has_intermediate_report: bool = True,
+    ):
         self.html_output = NamedTemporaryFile(
             "w+", delete=False, suffix=".html", encoding="utf-8"
         )
 
         logger = logging.getLogger()
 
-        intermediate_report = MergeReports(
-            merge_files=[
-                str(Path(__file__).parent.resolve() / "json" / "test_intermediate.json")
-            ],
-        )
-        intermediate_report.merge_intermediate()
+        intermediate_report = None
+
+        if has_intermediate_report:
+            intermediate_report = MergeReports(
+                merge_files=[
+                    str(
+                        Path(__file__).parent.resolve()
+                        / "json"
+                        / "test_intermediate.json"
+                    )
+                ],
+            )
+            intermediate_report.merge_intermediate()
 
         output_html(
-            all_cve_data,
-            None,
-            "",
-            "",
-            "",
-            10,
-            10,
-            0,
-            intermediate_report,
-            logger,
-            self.html_output,
+            all_cve_data=all_cve_data,
+            all_cve_version_info=None,
+            scanned_dir="/home/",
+            filename="",
+            theme_dir="",
+            total_files=10,
+            products_with_cve=10,
+            products_without_cve=0,
+            merge_report=intermediate_report,
+            logger=logger,
+            outfile=self.html_output,
         )
 
         self.page = page

--- a/test/test_html.py
+++ b/test/test_html.py
@@ -2,10 +2,17 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import re
+from unittest.mock import Mock
 
+import plotly.graph_objects as go
 import pytest
 from playwright.sync_api import Locator, Page, expect
 
+from cve_bin_tool.merge import MergeReports
+from cve_bin_tool.output_engine.html import (
+    get_intermediate_label,
+    load_timeline_from_merged,
+)
 from cve_bin_tool.util import CVE, CVEData, ProductInfo, Remarks
 
 from .pages.html_report import HTMLReport
@@ -46,6 +53,7 @@ class TestOutputHTML:
                     cvss_vector="CVSS3.0/C:H/I:L/A:M",
                     remarks=Remarks.Confirmed,
                     comments="",
+                    metric={"EPSS": (0.1234, 0.5678)},
                 )
             ],
             paths={""},
@@ -60,6 +68,7 @@ class TestOutputHTML:
                     cvss_vector="C:H/I:L/A:M",
                     remarks=Remarks.Mitigated,
                     comments="",
+                    metric={"Foo": (0.4321, 0.8765)},
                 )
             ],
             paths={""},
@@ -92,7 +101,7 @@ class TestOutputHTML:
             ],
             paths={""},
         ),
-        ProductInfo("vendor1", "product3", "6.2.1.0"): CVEData(
+        ProductInfo("UNKNOWN", "product3", "6.2.1.0"): CVEData(
             cves=[
                 CVE(
                     "CVE-1234-1006",
@@ -106,23 +115,55 @@ class TestOutputHTML:
             ],
             paths={""},
         ),
+        ProductInfo("vendor0", "product4", "1.0", "usr/local/bin/product"): CVEData(
+            cves=[
+                CVE(
+                    "UNKNOWN",
+                    "MEDIUM",
+                    score=4.2,
+                    cvss_version=2,
+                    cvss_vector="C:H",
+                    remarks=Remarks.NewFound,
+                    comments="showup",
+                )
+            ],
+            paths={""},
+        ),
+        ProductInfo("wildcard*", "product5", "7.2.1.0"): CVEData(
+            cves=[
+                CVE(
+                    "CVE-1234-1007",
+                    "CRITICAL",
+                    score=9.8,
+                    cvss_version=3.1,
+                    cvss_vector="CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H",
+                    remarks=Remarks.Confirmed,
+                    comments="",
+                )
+            ],
+            paths={""},
+        ),
     }
 
     @pytest.fixture(autouse=True)
     def setup_method(self, page: Page) -> None:
         """Setup method for HTML Testing."""
+
         self.page = page
         self.html_report_page = HTMLReport(page, self.MOCK_OUTPUT)
         self.html_report_page.load()
 
     def teardown_method(self) -> None:
         """Teardown method for HTML Testing."""
+
         if hasattr(self, "html_report_page") and self.html_report_page is not None:
             self.html_report_page.cleanup()
 
     def check_products_visible_hidden(
         self, visible_row: Locator, *hidden_rows: Locator
     ) -> None:
+        """Checks that the specified rows are visible or hidden."""
+
         for i in range(visible_row.count()):
             expect(visible_row.nth(i)).to_be_visible()
 
@@ -162,13 +203,13 @@ class TestOutputHTML:
         product_row.click()
         expect(modal_content).to_be_visible()
         modal_close_button.click()
-        expect(modal_content).to_be_hidden()
+        expect(modal_content).to_be_hidden(timeout=10000)
 
         vendor_product_pill.click()
         expect(modal_content).to_be_visible()
         expect(modal_content).to_contain_text("Comment: showup")
         modal_close_button.click()
-        expect(modal_content).to_be_hidden()
+        expect(modal_content).to_be_hidden(timeout=10000)
 
     def test_product_search(self) -> None:
         """Test Search function to filter the products"""
@@ -178,7 +219,7 @@ class TestOutputHTML:
         for i in range(product_rows.count()):
             expect(product_rows.nth(i)).to_be_visible()
 
-        expect(product_rows).to_have_count(6)
+        expect(product_rows).to_have_count(8)
         self.html_report_page.search_product("product0")
 
         filtered_row = product_rows.filter(
@@ -300,13 +341,28 @@ class TestOutputHTML:
             ]
         )
 
-    # Test for empty cve_data["cves"] list
+    def test_without_intermediate_report(self) -> None:
+        """Test that the HTML report renders correctly without an intermediate report."""
+
+        # Clean up the previous page so intermediate report is not present
+        if hasattr(self, "html_report_page") and self.html_report_page is not None:
+            self.html_report_page.cleanup()
+
+        self.html_report_page = HTMLReport(
+            self.html_report_page.page, self.MOCK_OUTPUT, False
+        )
+        self.html_report_page.load()
+        product_rows = self.html_report_page.product_rows
+
+        # This test can be improved once the HTML report has unique ids
+        expect(product_rows).to_have_count(8)
+
     def test_empty_cve_list(self) -> None:
         """Test that the HTML report renders correctly with an empty cve_data["cves"] list."""
+
         empty_output = {
             ProductInfo("vendor0", "product0", "1.0", "usr/local/bin/product"): CVEData(
-                cves=[],
-                paths={""},
+                cves=[], paths={""}
             )
         }
         if hasattr(self, "html_report_page") and self.html_report_page is not None:
@@ -314,31 +370,159 @@ class TestOutputHTML:
         self.html_report_page = HTMLReport(self.page, empty_output)
         self.html_report_page.load()
         product_rows = self.html_report_page.product_rows
+
         expect(product_rows).to_have_count(0)
 
-    # Test for cve_data["cves"] list with an element containing "UNKNOWN" CVE number
-    def test_unknown_cve_number(self) -> None:
-        """Test that the HTML report renders correctly with a cve_data["cves"] list containing an 'UNKNOWN' CVE number."""
-        unknown_cve_output = {
-            ProductInfo("vendor0", "product0", "1.0", "usr/local/bin/product"): CVEData(
-                cves=[
-                    CVE(
-                        "UNKNOWN",
-                        "MEDIUM",
-                        score=4.2,
-                        cvss_version=2,
-                        cvss_vector="C:H",
-                        remarks=Remarks.NewFound,
-                        comments="showup",
-                    )
-                ],
-                paths={""},
-            )
-        }
-        self.html_report_page.cleanup()  # Clean up the previous page
-        self.html_report_page = HTMLReport(
-            self.html_report_page.page, unknown_cve_output
-        )
-        self.html_report_page.load()
-        product_rows = self.html_report_page.product_rows
-        expect(product_rows).to_have_count(1)
+
+def test_get_intermediate_label_with_tag():
+    """Test get_intermediate_label returns correct format with tag"""
+
+    metadata = {"timestamp": "2025-03-04.12-00-00", "tag": "test-tag"}
+    expected_label = "04 Mar 12:00-test-tag"
+    assert get_intermediate_label(metadata) == expected_label
+
+
+def test_get_intermediate_label_without_tag():
+    """Test get_intermediate_label returns correct format without tag"""
+
+    metadata = {"timestamp": "2025-03-04.12-00-00", "tag": ""}
+    expected_label = "04 Mar 12:00"
+    assert get_intermediate_label(metadata) == expected_label
+
+
+def test_load_timeline_from_merged():
+    """Test load_timeline_from_merged returns correct figures"""
+
+    # Mock the MergeReports class
+    mock_merge_report = Mock(spec=MergeReports)
+    mock_merge_report.intermediate_cve_data = [
+        {
+            "metadata": {
+                "products_with_cve": 5,
+                "products_without_cve": 10,
+                "total_files": 15,
+                "severity": {
+                    "CRITICAL": 1,
+                    "HIGH": 2,
+                    "MEDIUM": 3,
+                    "LOW": 4,
+                    "UNKNOWN": 0,
+                },
+                "timestamp": "2025-03-04.12-00-00",
+                "tag": "test-tag",
+            }
+        },
+        {
+            "metadata": {
+                "products_with_cve": 3,
+                "products_without_cve": 7,
+                "total_files": 10,
+                "severity": {
+                    "CRITICAL": 0,
+                    "HIGH": 1,
+                    "MEDIUM": 2,
+                    "LOW": 3,
+                    "UNKNOWN": 0,
+                },
+                "timestamp": "2025-03-03.12-00-00",
+                "tag": "",
+            }
+        },
+    ]
+    mock_merge_report.get_intermediate_cve_scanner.return_value = [
+        Mock(
+            all_cve_data={
+                ProductInfo(
+                    product="product1", vendor="vendor1", version="1.0"
+                ): CVEData(cves=[("CVE-1234-1000", "HIGH")]),
+                ProductInfo(
+                    product="product2", vendor="vendor2", version="2.0"
+                ): CVEData(cves=[("CVE-1234-1001", "LOW")]),
+                ProductInfo(
+                    product="product3", vendor="vendor3", version="3.0"
+                ): CVEData(cves=[]),
+            }
+        ),
+        Mock(
+            all_cve_data={
+                ProductInfo(
+                    product="product3", vendor="vendor3", version="3.0"
+                ): CVEData(cves=[("CVE-1234-1002", "MEDIUM")]),
+                ProductInfo(
+                    product="product4", vendor="vendor4", version="4.0"
+                ): CVEData(cves=[("CVE-1234-1003", "CRITICAL")]),
+            }
+        ),
+    ]
+    mock_merge_report.score = 0
+
+    products_trace, total_files_trace, intermediate_timeline, severity_trace = (
+        load_timeline_from_merged(mock_merge_report)
+    )
+
+    # Check if the returned objects are of the correct type
+    assert isinstance(products_trace, go.Figure)
+    assert isinstance(total_files_trace, go.Figure)
+    assert isinstance(intermediate_timeline, go.Figure)
+    assert isinstance(severity_trace, go.Figure)
+
+    # Check if products_trace data in the figure is correct
+    assert products_trace.data[0].name == "Products with CVE"
+    assert products_trace.data[1].name == "Products without CVE"
+    assert products_trace.data[0].y == (
+        mock_merge_report.intermediate_cve_data[1]["metadata"]["products_with_cve"],
+        mock_merge_report.intermediate_cve_data[0]["metadata"]["products_with_cve"],
+    )
+    assert products_trace.data[1].y == (
+        mock_merge_report.intermediate_cve_data[1]["metadata"]["products_without_cve"],
+        mock_merge_report.intermediate_cve_data[0]["metadata"]["products_without_cve"],
+    )
+
+    # Check if total_files trace data in the figure is correct
+    assert total_files_trace.data[0].name == "Total Files"
+    assert total_files_trace.data[0].y == (
+        mock_merge_report.intermediate_cve_data[1]["metadata"]["total_files"],
+        mock_merge_report.intermediate_cve_data[0]["metadata"]["total_files"],
+    )
+
+    # Check if severity_trace data in the figures is correct
+    assert severity_trace.data[0].name == "CRITICAL"
+    assert severity_trace.data[0].y == (
+        mock_merge_report.intermediate_cve_data[1]["metadata"]["severity"]["CRITICAL"],
+        mock_merge_report.intermediate_cve_data[0]["metadata"]["severity"]["CRITICAL"],
+    )
+    assert severity_trace.data[1].name == "HIGH"
+    assert severity_trace.data[1].y == (
+        mock_merge_report.intermediate_cve_data[1]["metadata"]["severity"]["HIGH"],
+        mock_merge_report.intermediate_cve_data[0]["metadata"]["severity"]["HIGH"],
+    )
+    assert severity_trace.data[2].name == "MEDIUM"
+    assert severity_trace.data[2].y == (
+        mock_merge_report.intermediate_cve_data[1]["metadata"]["severity"]["MEDIUM"],
+        mock_merge_report.intermediate_cve_data[0]["metadata"]["severity"]["MEDIUM"],
+    )
+    assert severity_trace.data[3].name == "LOW"
+    assert severity_trace.data[3].y == (
+        mock_merge_report.intermediate_cve_data[1]["metadata"]["severity"]["LOW"],
+        mock_merge_report.intermediate_cve_data[0]["metadata"]["severity"]["LOW"],
+    )
+    assert severity_trace.data[4].name == "UNKNOWN"
+    assert severity_trace.data[4].y == (
+        mock_merge_report.intermediate_cve_data[1]["metadata"]["severity"]["UNKNOWN"],
+        mock_merge_report.intermediate_cve_data[0]["metadata"]["severity"]["UNKNOWN"],
+    )
+
+    # Sort intermediate_timeline data by name to ensure consistent order
+    intermediate_timeline_data_sorted = sorted(
+        intermediate_timeline.data, key=lambda x: x.name
+    )
+
+    # Check if the intermediate_timeline contains the correct product data
+    assert intermediate_timeline_data_sorted[0].name == "product1(1.0)"
+    assert intermediate_timeline_data_sorted[0].y == (1, 0)
+    assert intermediate_timeline_data_sorted[1].name == "product2(2.0)"
+    assert intermediate_timeline_data_sorted[1].y == (1, 0)
+    assert intermediate_timeline_data_sorted[2].name == "product3(3.0)"
+    assert intermediate_timeline_data_sorted[2].y == (0, 1)
+    assert intermediate_timeline_data_sorted[3].name == "product4(4.0)"
+    assert intermediate_timeline_data_sorted[3].y == (0, 1)


### PR DESCRIPTION
Fixed flaky test (#4864) by increasing the default timeout from 5 to 10 seconds), condensed tests, improved coverage from 84% to 100% (locally), reduced test execution time by half (locally).

Some improvements can be made, but are tied to report templates, e.g., the intermediate report sections are missing IDs making it impossible to locate elements to test, the metrics section has the same id as the summary section.

fixes: #4864