### PR TITLE
docs: docstring style guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -446,45 +446,25 @@ Note that the string started with the `f` followed by the string. Values are alw
 
 ### Docstring Formatting
 
-In general, docstrings should follow the Google docstring style guidelines as explained [here](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
+In general, docstrings should be added to all classes and methods. Some exclusions are `__init__` methods and tests where docstrings become redundant. Adding more details for arguments and return values are always a appreciated.
 
 Example:
 ```python
-def sum(a, b=0):
-   """
-   Calculates the sum of two given integers
+def func(param1, param2):
+    """Summary line - keep it short.
 
-   Args:
-      a (int): The first integer to add
-      b (int, optional): The second integer to add. Defaults to 0 if none specified.
-   
-   Returns:
-      int: The sum of the two input integers
-   """
-   return a + b
+    Extended description of function if necessary.
+
+    Args:
+        param1 (int): Description of param1
+        param2 (str): Description of param2
+
+    Returns:
+        bool: Description of return value
+    """
+    return True
 ```
-
-Example function with PEP 484 type annotations:
-```python
-def diff(a: int, b: int) -> int:
-   """
-   Calculates the difference of two given integers
-
-   Note:
-      Since the types are already defined, there is no need to define them within the docstring as well.
-
-   Args:
-      a: The integer being subtracted from (minuend)
-      b: The integer being subtracted (subtrahend)
-   
-   Returns:
-      The difference of the two integers
-   """
-   return a - b
-```
-
-
-Please try to adhere to these style standards in future docstrings (and update existing docstrings as necessary).
+Please try to adhere to these standards in future docstrings (and update existing docstrings as necessary).
 
 ## Making documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,13 +450,13 @@ In general, docstrings should follow the Google docstring style guidelines as ex
 
 Example:
 ```python
-def sum(a, b):
+def sum(a, b=0):
    """
    Calculates the sum of two given integers
 
    Args:
       a (int): The first integer to add
-      b (int): The second integer to add
+      b (int, optional): The second integer to add. Defaults to 0 if none specified.
    
    Returns:
       int: The sum of the two input integers

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,7 +450,7 @@ In general, docstrings should follow the Google docstring style guidelines as ex
 
 Example:
 ```python
-def foo(a, b : int):
+def foo(a, b: int):
    """
    Calculates the sum of two given integers
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -444,6 +444,31 @@ print(f"Name of the person is {name} and his age is {age}")
 
 Note that the string started with the `f` followed by the string. Values are always added in the curly braces. Also we don't need to convert age into string. (we may have used `str(age)` before using it in the string) f-strings are useful as they provide many cool features. You can read more about features and the good practices to use f-strings [here](https://realpython.com/python-f-strings/#f-strings-a-new-and-improved-way-to-format-strings-in-python).
 
+### Docstring Formatting
+
+In general, docstrings should follow the Google docstring style guidelines as explained [here](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html).
+
+Example:
+```python
+def foo(a, b : int):
+   """
+   Calculates the sum of two given integers
+
+   Note:
+      Specifying the arg types is not necessary if the args are strongly-typed
+
+   Args:
+      a (int): The first integer to add
+      b: The second integer to add
+   
+   Returns:
+      int: The sum of the two input integers
+   """
+   return a + b
+```
+
+Please try to adhere to these style standards in future docstrings (and update existing docstrings as necessary).
+
 ## Making documentation
 
 The documentation for CVE Binary Tool can be found in the `doc/` directory (with the exception of the README.md file, which is stored in the main directory but linked in the documentation directory for convenience).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -450,22 +450,39 @@ In general, docstrings should follow the Google docstring style guidelines as ex
 
 Example:
 ```python
-def foo(a, b: int):
+def sum(a, b):
    """
    Calculates the sum of two given integers
 
-   Note:
-      Specifying the arg types is not necessary if the args are strongly-typed
-
    Args:
       a (int): The first integer to add
-      b: The second integer to add
+      b (int): The second integer to add
    
    Returns:
       int: The sum of the two input integers
    """
    return a + b
 ```
+
+Example function with PEP 484 type annotations:
+```python
+def diff(a: int, b: int) -> int:
+   """
+   Calculates the difference of two given integers
+
+   Note:
+      Since the types are already defined, there is no need to define them within the docstring as well.
+
+   Args:
+      a: The integer being subtracted from (minuend)
+      b: The integer being subtracted (subtrahend)
+   
+   Returns:
+      The difference of the two integers
+   """
+   return a - b
+```
+
 
 Please try to adhere to these style standards in future docstrings (and update existing docstrings as necessary).
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ extend-ignore = E203, E501
 [tool:pytest]
 asyncio_mode = strict
 asyncio_default_fixture_loop_scope = function
+
+[tool:interrogate]
+style = google

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,6 +9,3 @@ extend-ignore = E203, E501
 [tool:pytest]
 asyncio_mode = strict
 asyncio_default_fixture_loop_scope = function
-
-[tool:interrogate]
-style = google


### PR DESCRIPTION
Proposal to specify a specific docstring style formatting for consistency. This should help improve readability especially when having to use a function or class that one may not be familiar with.

Current chosen style guidelines are Google docstrings as explained here: https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html, but also open to other style suggestions.

This PR adds the docstring style format guide to CONTRIBUTING.md, and also experiments with having interrogate adhere to the google style using setup.cfg (this can be taken out if we don't want to enforce the guidelines).